### PR TITLE
Add on attached listener to CountdownView to fix #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
-[![Android Gems](http://www.android-gems.com/badge/iwgang/CountdownView.svg?branch=master)](http://www.android-gems.com/lib/iwgang/CountdownView)
-[![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-CountdownView-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/2641) 
-[![@iwgang](https://img.shields.io/badge/weibo-%40iwgang-blue.svg)](http://weibo.com/iwgang)
-
-#### [中文](https://github.com/iwgang/CountdownView/blob/master/README_CN.md)
+Get my version of the latest release via jitpack here:
+[![](https://jitpack.io/v/ahaverty/CountdownView.svg)](https://jitpack.io/#ahaverty/CountdownView)
 
 
 # CountdownView

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "cn.iwgang.countdownviewdemo"

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri May 19 13:13:46 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 10

--- a/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
+++ b/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
@@ -17,6 +17,7 @@ public class CountdownView extends View {
     private CustomCountDownTimer mCustomCountDownTimer;
     private OnCountdownEndListener mOnCountdownEndListener;
     private OnCountdownIntervalListener mOnCountdownIntervalListener;
+    private OnAttachedToWindowListener mOnAttachedToWindowListener;
 
     private boolean isHideTimeBackground;
     private long mPreviousIntervalCallbackTime;
@@ -95,6 +96,13 @@ public class CountdownView extends View {
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         stop();
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        long timeRemaining = mOnAttachedToWindowListener.onAttached();
+        start(timeRemaining);
     }
 
     private void reLayout() {
@@ -193,6 +201,10 @@ public class CountdownView extends View {
     public void allShowZero() {
         mCountdown.setTimes(0, 0, 0, 0, 0);
         invalidate();
+    }
+
+    public void setOnAttachedToWindowListener(OnAttachedToWindowListener onAttachedToWindowListener) {
+        mOnAttachedToWindowListener = onAttachedToWindowListener;
     }
 
     /**
@@ -299,6 +311,10 @@ public class CountdownView extends View {
 
     public interface OnCountdownIntervalListener {
         void onInterval(CountdownView cv, long remainTime);
+    }
+
+    public interface OnAttachedToWindowListener {
+        long onAttached();
     }
 
     /**

--- a/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
+++ b/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
@@ -117,7 +117,10 @@ public class CountdownView extends View {
      * @param millisecond millisecond
      */
     public void start(long millisecond) {
-        if (millisecond <= 0) return;
+        if (millisecond <= 0) {
+            allShowZero();
+            return;
+        }
 
         mPreviousIntervalCallbackTime = 0;
 

--- a/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
+++ b/library/src/main/java/cn/iwgang/countdownview/CountdownView.java
@@ -100,9 +100,11 @@ public class CountdownView extends View {
 
     @Override
     protected void onAttachedToWindow() {
-        super.onAttachedToWindow();
-        long timeRemaining = mOnAttachedToWindowListener.onAttached();
-        start(timeRemaining);
+        if (!isInEditMode()) {
+            super.onAttachedToWindow();
+            long timeRemaining = mOnAttachedToWindowListener.onAttached();
+            start(timeRemaining);
+        }
     }
 
     private void reLayout() {


### PR DESCRIPTION
Added an on attached interface listener to allow starting the countdown again with specified millisecond long to fix #45 
Added in the event that onDetachedFromWindow is called (which stops the countdown)
onDetached occurs if list items in a recycler view go out of view